### PR TITLE
Pin r-base (CONDA_R) to major.minor version instead of full version.

### DIFF
--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -240,11 +240,11 @@ class Test_special_case_version_matrix(unittest.TestCase):
 
     def test_r_matrix(self):
         a = DummyPackage('pkgA', ['r-base'])
-        self.index.add_pkg('r-base', '4.5.6')
-        self.index.add_pkg('r-base', '4.5.7')
+        self.index.add_pkg('r-base', '4.5')
+        self.index.add_pkg('r-base', '4.5')
         r = special_case_version_matrix(a, self.index)
-        self.assertEqual(r, set(((('r-base', '4.5.6'),),
-                                 (('r-base', '4.5.7'),),
+        self.assertEqual(r, set(((('r-base', '4.5'),),
+                                 (('r-base', '4.5'),),
                                 ))
                          )
 
@@ -254,18 +254,18 @@ class Test_special_case_version_matrix(unittest.TestCase):
         self.index.add_pkg('perl', '4.5.7')
         self.index.add_pkg('python', '2.7')
         self.index.add_pkg('python', '3.5')
-        self.index.add_pkg('r-base', '1.2.3')
-        self.index.add_pkg('r-base', '4.5.6')
+        self.index.add_pkg('r-base', '1.2')
+        self.index.add_pkg('r-base', '4.5')
 
         r = special_case_version_matrix(a, self.index)
-        expected = set(((('python', '2.7'), ('perl', '4.5.6'), ('r-base', '1.2.3')),
-                        (('python', '2.7'), ('perl', '4.5.6'), ('r-base', '4.5.6')),
-                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '4.5.6')),
-                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '4.5.6')),
-                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '1.2.3')),
-                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '4.5.6')),
+        expected = set(((('python', '2.7'), ('perl', '4.5.6'), ('r-base', '1.2')),
+                        (('python', '2.7'), ('perl', '4.5.6'), ('r-base', '4.5')),
+                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '1.2')),
+                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '1.2')),
+                        (('python', '3.5'), ('perl', '4.5.7'), ('r-base', '4.5')),
+                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '4.5')),
+                        (('python', '2.7'), ('perl', '4.5.7'), ('r-base', '1.2')),
+                        (('python', '3.5'), ('perl', '4.5.6'), ('r-base', '4.5')),
                         ))
         self.assertEqual(r, expected)
 

--- a/conda_build_all/version_matrix.py
+++ b/conda_build_all/version_matrix.py
@@ -238,7 +238,7 @@ def special_case_version_matrix(meta, index):
             r_spec = requirement_specs.pop('r-base')
             for case_base in list(cases or [()]):
                 for r_pkg in get_pkgs(r_spec):
-                    r_vn = index[r_pkg.fn]['version']
+                    r_vn = minor_vn(index[r_pkg.fn]['version'])
                     case = case_base + (('r-base', r_vn), )
                     add_case_if_soluble(case)
                 if case_base in cases:


### PR DESCRIPTION
This has been discussed in conda-forge/r-base-feedstock#16. The benefit is that
we don't have to rebuild everything for every released patch version.
R does not explicitly say that it follows semantic versioning, however the codebase
gives strong evidence for this:

1. In the sources (base/R/library.R), they have an error if a package was build before 3.0.0, and a warning if a package was built with a newer version than the current. No warning in case of an older version.
2. The function update.packages() from r-base, which is recommended to be executed after updating R and copying over packages to the new version (as e.g. done by installr), has an option checkBuilt, which, when set to true rebuilds packages if and only if the package has been built under an older major.minor version. Not under a changed patch version.

In summary, all built-in facilities are designed to take care for major.minor updates, implying that major.minor.patch updates are safe and need no rebuild.

ping @jakirkham, @mingwandroid, @ocefpaf, @bgruening.