### PR TITLE
add a conda_interface module and use conda.exports

### DIFF
--- a/conda_build_all/artefact_destination.py
+++ b/conda_build_all/artefact_destination.py
@@ -17,10 +17,9 @@ import posixpath as urlpath
 
 import binstar_client.utils
 import binstar_client
-from conda.api import get_index
+from .conda_interface import get_index
 from conda_build.metadata import MetaData
 from conda_build.build import bldpkg_path
-import conda.config
 
 from . import inspect_binstar
 from . import build

--- a/conda_build_all/build.py
+++ b/conda_build_all/build.py
@@ -8,7 +8,7 @@ import shutil
 import conda_build.build as build_module
 from conda_build.metadata import MetaData
 import conda_build.config
-from conda.lock import Locked
+from .conda_interface import Locked
 
 try:
     from conda_build.api import get_output_file_path

--- a/conda_build_all/conda_interface.py
+++ b/conda_build_all/conda_interface.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+
+from conda import __version__ as CONDA_VERSION
+
+CONDA_VERSION_MAJOR_MINOR = tuple(int(x) for x in CONDA_VERSION.split('.')[:2])
+
+if (4, 3) <= CONDA_VERSION_MAJOR_MINOR < (4, 4):
+    from conda.lock import Locked
+    from conda.exports import get_index
+    from conda.exports import subdir
+    from conda.exports import MatchSpec
+    from conda.exports import Unsatisfiable
+    from conda.exports import NoPackagesFound
+    from conda.exports import Resolve
+    from conda.models.dist import Dist as _Dist
+
+    def get_key(dist_or_filename):
+        return dist_or_filename
+
+    def copy_index(index):
+        return {_Dist(key): index[key] for key in index.keys()}
+
+    def ensure_dist_or_dict(fn):
+        return _Dist.from_string(fn)
+
+    from conda.console import setup_verbose_handlers
+    setup_verbose_handlers()
+    from conda.gateways.logging import initialize_logging
+    initialize_logging()
+
+elif (4, 2) <= CONDA_VERSION_MAJOR_MINOR < (4, 3):
+    from conda.lock import Locked
+    from conda.exports import get_index
+    from conda.exports import subdir
+    from conda.exports import MatchSpec
+    from conda.exports import Unsatisfiable
+    from conda.exports import NoPackagesFound
+    from conda.exports import Resolve
+
+    def get_key(dist_or_filename):
+        return dist_or_filename.fn
+
+    def copy_index(index):
+        index = index.copy()
+        return index
+
+    def ensure_dist_or_dict(fn):
+        return fn
+
+    # We need to import conda.fetch and conda.resolve to trigger the
+    # creation of the loggers.
+    import conda.fetch
+    import conda.resolve
+
+else:
+    raise NotImplementedError("CONDA_VERSION: %s  CONDA_VERSION_MAJOR_MINOR: %s"
+                              % (CONDA_VERSION, str(CONDA_VERSION_MAJOR_MINOR)))
+
+
+subdir = subdir
+Locked = Locked
+Resolve, get_index = Resolve, get_index
+MatchSpec = MatchSpec
+Unsatisfiable, NoPackagesFound = Unsatisfiable, NoPackagesFound

--- a/conda_build_all/inspect_binstar.py
+++ b/conda_build_all/inspect_binstar.py
@@ -1,9 +1,8 @@
 # NOTE: This module has no unit tests.
 
-import conda.config
 import binstar_client
 from conda_build.build import bldpkg_path
-from conda.api import get_index
+from .conda_interface import get_index, subdir
 
 
 def distribution_exists(binstar_cli, owner, metadata):
@@ -12,7 +11,7 @@ def distribution_exists(binstar_cli, owner, metadata):
 
     This does not check specific channels - it is either on binstar or it is not.
     """
-    fname = '{}/{}.tar.bz2'.format(conda.config.subdir, metadata.dist())
+    fname = '{}/{}.tar.bz2'.format(subdir, metadata.dist())
     try:
         r = binstar_cli.distribution(owner, metadata.name(), metadata.version(),
                                      fname)
@@ -37,7 +36,7 @@ def distribution_exists_on_channel(binstar_cli, owner, metadata, channel='main')
 
     try:
         on_channel = (distributions_on_channel[fname]['subdir'] ==
-                      conda.config.subdir)
+                      subdir)
     except KeyError:
         on_channel = False
     return on_channel
@@ -51,7 +50,7 @@ def add_distribution_to_channel(binstar_cli, owner, metadata, channel='main'):
     so if you have a foo-0.1-np18 and foo-0.1-np19 *both* will be added to the channel.
 
     """
-    package_fname = '{}/{}.tar.bz2'.format(conda.config.subdir, metadata.dist())
+    package_fname = '{}/{}.tar.bz2'.format(subdir, metadata.dist())
     binstar_cli.add_channel(channel, owner, metadata.name(), metadata.version())#filename=package_fname)
 
 
@@ -61,7 +60,7 @@ def copy_distribution_to_owner(binstar_cli, source_owner, dest_owner,
     Copy an already existing distribution from one owner to another on
     anaconda.
     """
-    package_fname = '{}/{}.tar.bz2'.format(conda.config.subdir, metadata.dist())
+    package_fname = '{}/{}.tar.bz2'.format(subdir, metadata.dist())
     binstar_cli.copy(source_owner, metadata.name(), metadata.version(),
                      basename=package_fname, to_owner=dest_owner,
                      to_channel=channel)

--- a/conda_build_all/resolved_distribution.py
+++ b/conda_build_all/resolved_distribution.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 
-from conda.api import get_index
-import conda.config
+from .conda_interface import get_index
 import conda_build.config
 
 

--- a/conda_build_all/tests/integration/test_cli.py
+++ b/conda_build_all/tests/integration/test_cli.py
@@ -14,7 +14,6 @@ import textwrap
 import unittest
 
 from binstar_client.utils import get_binstar
-import conda.config
 
 from conda_build_all.build import build, upload
 from conda_build_all.inspect_binstar import (distribution_exists,
@@ -22,6 +21,7 @@ from conda_build_all.inspect_binstar import (distribution_exists,
                                              add_distribution_to_channel)
 from conda_build_all.tests.integration.test_builder import RecipeCreatingUnit
 from conda_build_all.resolved_distribution import ResolvedDistribution
+from conda_build_all.conda_interface import subdir
 
 
 def clear_binstar(cli, owner):
@@ -129,14 +129,14 @@ class Test(RecipeCreatingUnit):
         self.assertFalse(distribution_exists_on_channel(CLIENT, OWNER, a_py99, channel='testing'))
 
         # Remove the built distribution, re-run, and assert that we didn't bother re-building.
-        dist_path = os.path.join(self.conda_bld_root, conda.config.subdir, a_py21.pkg_fn())
+        dist_path = os.path.join(self.conda_bld_root, subdir, a_py21.pkg_fn())
         self.assertTrue(os.path.exists(dist_path))
         os.remove(dist_path)
         self.call([self.recipes_root_dir, '--inspect-channel', testing_channel, '--upload-channel', testing_channel])
         self.assertFalse(os.path.exists(dist_path))
 
         # Now put a condition in. In this case, only build dists for py<2
-        CLIENT.remove_dist(OWNER, a_py21.name(), a_py21.version(), '{}/{}'.format(conda.config.subdir, a_py21.pkg_fn()))
+        CLIENT.remove_dist(OWNER, a_py21.name(), a_py21.version(), '{}/{}'.format(subdir, a_py21.pkg_fn()))
         self.assertFalse(distribution_exists_on_channel(CLIENT, OWNER, a_py21, channel='testing'))
         self.call([self.recipes_root_dir, '--inspect-channel', testing_channel, '--upload-channel', testing_channel,
                    '--matrix-condition', 'python <2'])

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -9,8 +9,8 @@ try:
 except ImportError:
     import conda_build
     extra_config = True
-import conda.config
 
+from conda_build_all.conda_interface import subdir
 
 _DummyPackage = collections.namedtuple('_DummyPackage',
                                        ['pkg_name', 'build_deps',
@@ -53,7 +53,7 @@ class DummyIndex(dict):
         else:
             build_string = build_number
         pkg_info = dict(name=name, version=version, build_number=build_number,
-                        build=build_string, subdir=conda.config.subdir,
+                        build=build_string, subdir=subdir,
                         depends=tuple(depends), **extra_items)
         self['{}-{}-{}.tar.bz2'.format(name, version, build_string)] = pkg_info
 
@@ -67,7 +67,7 @@ class DummyIndex(dict):
     def write_to_channel(self, dest):
         # Write the index to a channel. Useful to get conda to read it back in again
         # using conda.api.get_index().
-        channel_subdir = os.path.join(dest, conda.config.subdir)
+        channel_subdir = os.path.join(dest, subdir)
         if not os.path.exists(channel_subdir):
             os.mkdir(channel_subdir)
         if hasattr(conda_build, 'api'):

--- a/conda_build_all/tests/unit/test_version_matrix.py
+++ b/conda_build_all/tests/unit/test_version_matrix.py
@@ -1,7 +1,6 @@
 import unittest
 
-import conda.config
-from conda.resolve import MatchSpec
+from conda_build_all.conda_interface import MatchSpec
 
 from conda_build_all.version_matrix import (parse_specifications,
                                             special_case_version_matrix,


### PR DESCRIPTION
This PR should fix https://github.com/conda-tools/conda-build-all/issues/91.  It converts most imports of conda to `conda.exports`, which is the longer-term interface to conda's internals.  It also isolates all imports for conda to a single location, so they're more easily updated for future major releases of conda.