### PR TITLE
conda 4.4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
     # Now do the things we need to do to install it.
     - conda install -c conda-forge --file requirements.txt nose mock python=${PYTHON} ${EXTRA_DEPS} --yes --quiet
-    - if [[ -n ${CONDA_ORIGIN} ]]; then conda install -yq -c ${CONDA_ORIGIN} conda conda-build; fi
+    - if [[ -n ${CONDA_ORIGIN} ]]; then conda install -yq -c ${CONDA_ORIGIN} conda conda-build=2.1; fi
     - python setup.py install
     - mkdir not_the_source_root && cd not_the_source_root
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 
     # Now do the things we need to do to install it.
     - conda install -c conda-forge --file requirements.txt nose mock python=${PYTHON} ${EXTRA_DEPS} --yes --quiet
-    - if [[ -n ${CONDA_ORIGIN} ]]; then conda install -yq -c ${CONDA_ORIGIN} conda conda-build=2.1; fi
+    - if [[ -n ${CONDA_ORIGIN} ]]; then conda install -yq -c ${CONDA_ORIGIN} conda conda-build; fi
     - python setup.py install
     - mkdir not_the_source_root && cd not_the_source_root
 

--- a/conda_build_all/conda_interface.py
+++ b/conda_build_all/conda_interface.py
@@ -12,7 +12,6 @@ if (4, 4) <= CONDA_VERSION_MAJOR_MINOR < (4, 5):
     from conda.exports import MatchSpec
     from conda.exports import Unsatisfiable
     from conda.exports import NoPackagesFound
-    from conda.exports import Resolve
     from conda.exports import string_types
     from conda.models.dist import Dist as _Dist
 
@@ -28,6 +27,16 @@ if (4, 4) <= CONDA_VERSION_MAJOR_MINOR < (4, 5):
     from conda.gateways.logging import initialize_logging, set_verbosity
     initialize_logging()
     set_verbosity(1)
+
+    from conda.exports import Resolve as _Resolve
+    from conda.models.index_record import PackageRecord as _PackageRecord
+
+    class Resolve(_Resolve):
+        def __init__(self, index):
+            # ensure conversion of dicts to PackageRecord objects
+            super(Resolve, self).__init__(
+                {dist: _PackageRecord.from_objects(rec) for dist, rec in index.items()}
+            )
 
 elif (4, 3) <= CONDA_VERSION_MAJOR_MINOR < (4, 4):
     from conda.lock import Locked

--- a/conda_build_all/conda_interface.py
+++ b/conda_build_all/conda_interface.py
@@ -30,12 +30,13 @@ if (4, 4) <= CONDA_VERSION_MAJOR_MINOR < (4, 5):
 
     from conda.exports import Resolve as _Resolve
     from conda.models.index_record import PackageRecord as _PackageRecord
+    from conda.models.dist import Dist as _Dist
 
     class Resolve(_Resolve):
         def __init__(self, index):
             # ensure conversion of dicts to PackageRecord objects
             super(Resolve, self).__init__(
-                {dist: _PackageRecord.from_objects(rec) for dist, rec in index.items()}
+                {_Dist(dist): _PackageRecord.from_objects(rec) for dist, rec in index.items()}
             )
 
 elif (4, 3) <= CONDA_VERSION_MAJOR_MINOR < (4, 4):

--- a/conda_build_all/conda_interface.py
+++ b/conda_build_all/conda_interface.py
@@ -5,7 +5,31 @@ from conda import __version__ as CONDA_VERSION
 
 CONDA_VERSION_MAJOR_MINOR = tuple(int(x) for x in CONDA_VERSION.split('.')[:2])
 
-if (4, 3) <= CONDA_VERSION_MAJOR_MINOR < (4, 4):
+if (4, 4) <= CONDA_VERSION_MAJOR_MINOR < (4, 5):
+    from conda.lock import Locked
+    from conda.exports import get_index
+    from conda.exports import subdir
+    from conda.exports import MatchSpec
+    from conda.exports import Unsatisfiable
+    from conda.exports import NoPackagesFound
+    from conda.exports import Resolve
+    from conda.exports import string_types
+    from conda.models.dist import Dist as _Dist
+
+    def get_key(dist_or_filename):
+        return dist_or_filename
+
+    def copy_index(index):
+        return {_Dist(key): index[key] for key in index.keys()}
+
+    def ensure_dist_or_dict(fn):
+        return _Dist.from_string(fn)
+
+    from conda.gateways.logging import initialize_logging, set_verbosity
+    initialize_logging()
+    set_verbosity(1)
+
+elif (4, 3) <= CONDA_VERSION_MAJOR_MINOR < (4, 4):
     from conda.lock import Locked
     from conda.exports import get_index
     from conda.exports import subdir

--- a/conda_build_all/tests/unit/dummy_index.py
+++ b/conda_build_all/tests/unit/dummy_index.py
@@ -46,7 +46,7 @@ class DummyPackage(_DummyPackage):
 
 class DummyIndex(dict):
     def add_pkg(self, name, version, build_string='',
-                depends=(), build_number='0',
+                depends=(), build_number=0,
                 **extra_items):
         if build_string:
             build_string = '{}_{}'.format(build_string, build_number)


### PR DESCRIPTION
The only change here for conda 4.4 is a small tweak in logging initialization.  I just got my first issue reported that I believe to be a result of thrashing between conda 4.3 and 4.4: https://github.com/conda/conda/issues/6804.  Conda 4.4 has been out for over a month now, and it's been pretty stable since the initial release (was in canary for months).  Probably time to get the conda-forge upgrade pushed through for conda-forge users.